### PR TITLE
Update profile picture, typography, and layout improvements

### DIFF
--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -8,7 +8,7 @@ const Section: FC<AllHTMLAttributes<HTMLDivElement>> = ({
 }) => {
   return (
     <section {...props} className={clsx(className)}>
-      <div className="container mx-auto sm:px-4">{children}</div>
+      <div className="container mx-auto sm:px-4" style={{ maxWidth: '1200px' }}>{children}</div>
     </section>
   );
 };

--- a/components/SocialLinks.module.scss
+++ b/components/SocialLinks.module.scss
@@ -2,6 +2,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  padding-top: 1em;
 
   li {
     display: inline-block;
@@ -13,6 +14,7 @@
   }
 
   .icon {
-    width: 2em;
+    width: 2.5em;
+    height: 2.5em;
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,23 +24,24 @@ export default function Home({
       <Head>
         <title>Zack Low - Engineering Leader</title>
         <link rel="shortcut icon" href="/static/favicon.ico" />
-        <link rel="preload" as="image" href="/static/prof.webp" />
+        <link rel="preload" as="image" href="/static/gg-zack-low-portrait.jpg" />
         <meta
           name="description"
           content="AI-focused engineering leader passionate about building data-driven, product-focused agile engineering teams by fostering collaborative environments."
         />
       </Head>
       <Hero className="py-2">
-        <div className="container mx-auto sm:px-4 p-6">
+        <div className="container mx-auto sm:px-4 p-6" style={{ maxWidth: '1200px' }}>
           <div className="flex flex-wrap items-center">
             <div className="sm:w-2/5 lg:w-1/4 pr-4 pl-4 pt-4 sm:pt-0 lg:ps-4 lg:pe-12 flex items-center">
-              <div className="shadow-lg flex rounded-full overflow-hidden">
+              <div className="shadow-lg flex overflow-hidden" style={{ borderRadius: '9999px', maxHeight: '270px' }}>
                 <Image
-                  src="/static/prof.webp"
+                  src="/static/gg-zack-low-portrait.jpg"
                   className="profile"
-                  width={600}
-                  height={600}
+                  width={180}
+                  height={270}
                   alt="Profile picture of Zack Low"
+                  style={{ borderRadius: '9999px', maxHeight: '270px', width: 'auto', height: '100%' }}
                 />
               </div>
             </div>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,30 +1,56 @@
 @import "tailwindcss";
 
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:wght@300;600;700&family=Albert+Sans:wght@300;400&display=swap");
+
 @layer base {
   h1, .h1 {
     @apply text-5xl;
+    font-family: 'Fraunces', serif;
+    font-weight: 300;
+    letter-spacing: -0.02em; /* -2% */
   }
   h2, .h2 {
     @apply text-3xl;
+    font-family: 'Fraunces', serif;
+    font-weight: 300;
+    letter-spacing: -0.015em; /* -1.5% */
   }
   h3, .h3 {
-    @apply text-2xl
+    @apply text-2xl;
+    font-family: 'Fraunces', serif;
+    font-weight: 300;
+    letter-spacing: -0.015em; /* -1.5% */
   }
   ul {
-    @apply list-disc ml-4 pl-4
+    @apply list-disc ml-4 pl-4;
+    font-family: 'Albert Sans', sans-serif;
+    font-weight: 300;
+    line-height: 1.6;
+  }
+  li {
+    font-family: 'Albert Sans', sans-serif;
+    font-weight: 300;
+    line-height: 1.6;
   }
   p {
-    @apply text-lg leading-6 font-light
+    @apply text-lg;
+    font-family: 'Albert Sans', sans-serif;
+    font-weight: 300;
+    line-height: 1.6; /* 1.6 is within the 1.55-1.65 range */
+  }
+  small {
+    font-family: 'Albert Sans', sans-serif;
+    font-weight: 400;
   }
 }
-
-@import url("https://fonts.googleapis.com/css2?family=Mulish:wght@300&family=Raleway:wght@300&display=swap");
 
 html,
 body {
   padding: 0;
   margin: 0;
-  font-family: Mulish, Helvetica, Arial, sans-serif;
+  font-family: 'Albert Sans', sans-serif;
+  font-weight: 300;
+  line-height: 1.6;
 }
 
 h1,
@@ -33,11 +59,13 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: Raleway, sans-serif;
+  font-family: 'Fraunces', serif;
 }
 
 .family-primary {
-  font-family: Mulish, Helvetica, Arial, sans-serif;
+  font-family: 'Albert Sans', sans-serif;
+  font-weight: 300;
+  line-height: 1.6;
 }
 
 * {
@@ -46,5 +74,21 @@ h6 {
 
 .border-chip {
   border-radius: 1px 5px 5px 5px;
+}
+
+/* Responsive font sizing for large screens */
+@media (min-width: 1200px) {
+  h1, .h1 {
+    font-size: 2.5rem; /* Reduced from text-5xl (3rem) */
+  }
+  h2, .h2 {
+    font-size: 1.75rem; /* Reduced from text-3xl (1.875rem) */
+  }
+  h3, .h3 {
+    font-size: 1.5rem; /* Reduced from text-2xl (1.5rem) - keep same or slightly reduce */
+  }
+  p {
+    font-size: 1rem; /* Reduced from text-lg (1.125rem) */
+  }
 }
 


### PR DESCRIPTION
## Changes

- **Profile Picture**: Replaced with new portrait image (gg-zack-low-portrait.jpg) styled as a pill shape with max border radius
- **Typography**: 
  - Updated to Fraunces Light (300) for headers
  - Albert Sans (300) for body text, (400) for meta text
  - Added responsive font sizing for large screens (≥1200px)
- **Layout**: 
  - Constrained content to 1200px max-width on large screens
  - Updated Section component to respect max-width constraint
- **Social Links**: Increased icon size and added top padding